### PR TITLE
generate-repology-metadata: add urls to patches and build recipe to generated json

### DIFF
--- a/.github/workflows/repology_metadata.yml
+++ b/.github/workflows/repology_metadata.yml
@@ -16,8 +16,8 @@ jobs:
         token: ${{ secrets.GH_TOKEN }}
     - name: Install json tools
       run: |
-        apt update
-        apt install -yq jq
+        sudo apt update
+        sudo apt install -yq jq
     - name: Clone Termux package repositories
       run: |
         mkdir -p /tmp/repos

--- a/packages.json
+++ b/packages.json
@@ -8711,11 +8711,11 @@
   },
   {
     "name": "patchelf",
-    "version": "0.14.3",
+    "version": "0.14.5",
     "description": "Utility to modify the dynamic linker and RPATH of ELF executables",
     "homepage": "https://nixos.org/patchelf.html",
     "depends": ["libc++"],
-    "srcurl": "https://github.com/NixOS/patchelf/archive/0.14.3.tar.gz",
+    "srcurl": "https://github.com/NixOS/patchelf/archive/0.14.5.tar.gz",
     "maintainer": "@termux"
   },
   {

--- a/packages.json
+++ b/packages.json
@@ -754,11 +754,11 @@
   },
   {
     "name": "brook",
-    "version": "20210701",
+    "version": "20220401",
     "description": "A cross-platform strong encryption and not detectable proxy. Zero-Configuration.",
     "homepage": "https://github.com/txthinking/brook",
     "depends": [],
-    "srcurl": "https://github.com/txthinking/brook/archive/v20210701.tar.gz",
+    "srcurl": "https://github.com/txthinking/brook/archive/v20220401.tar.gz",
     "maintainer": "Krishna kanhaiya @kcubeterm"
   },
   {
@@ -2504,11 +2504,11 @@
   },
   {
     "name": "fselect",
-    "version": "0.7.9",
+    "version": "0.8.0",
     "description": "Find files with SQL-like queries",
     "homepage": "https://github.com/jhspetersson/fselect",
     "depends": [],
-    "srcurl": "https://github.com/jhspetersson/fselect/archive/0.7.9.tar.gz",
+    "srcurl": "https://github.com/jhspetersson/fselect/archive/0.8.0.tar.gz",
     "maintainer": "@termux"
   },
   {
@@ -3160,11 +3160,11 @@
   },
   {
     "name": "gradle",
-    "version": "1:7.3.3",
+    "version": "1:7.4",
     "description": "Powerful build system for the JVM",
     "homepage": "https://gradle.org/",
     "depends": ["openjdk-17"],
-    "srcurl": "https://services.gradle.org/distributions/gradle-7.3.3-bin.zip",
+    "srcurl": "https://services.gradle.org/distributions/gradle-7.4-bin.zip",
     "maintainer": "@termux"
   },
   {
@@ -4988,10 +4988,10 @@
   },
   {
     "name": "libgrpc",
-    "version": "1.38.1",
+    "version": "1.44.0",
     "description": "High performance, open source, general RPC framework that puts mobile and HTTP/2 first",
     "homepage": "https://grpc.io/",
-    "depends": ["libc++", "openssl", "protobuf", "c-ares", "zlib"],
+    "depends": ["ca-certificates", "libc++", "libre2", "openssl", "protobuf", "c-ares", "zlib"],
     "srcurl": "https://github.com/grpc/grpc.git",
     "maintainer": "@termux"
   },
@@ -7151,7 +7151,7 @@
     "version": "1.4.19",
     "description": "Traditional Unix macro processor",
     "homepage": "https://www.gnu.org/software/m4/m4.html",
-    "depends": ["libandroid-spawn"],
+    "depends": [],
     "srcurl": "https://mirrors.kernel.org/gnu/m4/m4-1.4.19.tar.xz",
     "maintainer": "@termux"
   },
@@ -8235,11 +8235,11 @@
   },
   {
     "name": "nushell",
-    "version": "0.35.0",
+    "version": "0.44.0",
     "description": "A new type of shell operating on structured data",
     "homepage": "https://www.nushell.sh",
     "depends": ["openssl", "zlib"],
-    "srcurl": "https://github.com/nushell/nushell/archive/0.35.0.tar.gz",
+    "srcurl": "https://github.com/nushell/nushell/archive/0.44.0.tar.gz",
     "maintainer": "@termux"
   },
   {
@@ -11597,6 +11597,15 @@
     "homepage": "https://www.wireguard.com",
     "depends": [],
     "srcurl": "https://git.zx2c4.com/wireguard-tools/snapshot/wireguard-tools-1.0.20210424.tar.xz",
+    "maintainer": "@termux"
+  },
+  {
+    "name": "wiz",
+    "version": "2021.06.02",
+    "description": "A high-level assembly language for writing homebrew software for retro console platforms",
+    "homepage": "http://wiz-lang.org/",
+    "depends": ["libc++"],
+    "srcurl": "https://github.com/wiz-lang/wiz.git",
     "maintainer": "@termux"
   },
   {

--- a/packages.json
+++ b/packages.json
@@ -780,6 +780,15 @@
     "maintainer": "@termux"
   },
   {
+    "name": "bsd-games",
+    "version": "2021.11.15",
+    "description": "Classic text mode games from UNIX folklore",
+    "homepage": "https://www.polyomino.org.uk/computer/software/bsd-games/",
+    "depends": ["ncurses"],
+    "srcurl": "https://github.com/msharov/bsd-games.git",
+    "maintainer": "@termux"
+  },
+  {
     "name": "btfs",
     "version": "1.6.0",
     "description": "Decentralized file system integrating with TRON network",
@@ -3775,6 +3784,15 @@
     "homepage": "https://wiki.linuxfoundation.org/networking/iproute2",
     "depends": ["libandroid-glob", "libandroid-support"],
     "srcurl": "https://www.kernel.org/pub/linux/utils/net/iproute2/iproute2-5.15.0.tar.xz",
+    "maintainer": "@termux"
+  },
+  {
+    "name": "ipv6toolkit",
+    "version": "2021.03.30",
+    "description": "SI6 Networks IPv6 Toolkit",
+    "homepage": "https://www.si6networks.com/research/tools/ipv6toolkit/",
+    "depends": ["libpcap"],
+    "srcurl": "https://github.com/fgont/ipv6toolkit.git",
     "maintainer": "@termux"
   },
   {
@@ -10005,11 +10023,11 @@
   },
   {
     "name": "shfmt",
-    "version": "3.4.2",
+    "version": "3.4.3",
     "description": "A shell parser and formatter",
     "homepage": "https://github.com/mvdan/sh",
     "depends": [],
-    "srcurl": "https://github.com/mvdan/sh/archive/v3.4.2.tar.gz",
+    "srcurl": "https://github.com/mvdan/sh/archive/v3.4.3.tar.gz",
     "maintainer": "@termux"
   },
   {
@@ -10963,11 +10981,11 @@
   },
   {
     "name": "tor",
-    "version": "0.4.6.9",
+    "version": "0.4.6.10",
     "description": "The Onion Router anonymizing overlay network",
     "homepage": "https://www.torproject.org",
     "depends": ["libevent", "openssl", "liblzma", "zlib", "libandroid-glob"],
-    "srcurl": "https://www.torproject.org/dist/tor-0.4.6.9.tar.gz",
+    "srcurl": "https://www.torproject.org/dist/tor-0.4.6.10.tar.gz",
     "maintainer": "@termux"
   },
   {
@@ -11489,6 +11507,15 @@
     "homepage": "http://w3m.sourceforge.net/",
     "depends": ["libgc", "ncurses", "openssl", "zlib"],
     "srcurl": "https://github.com/tats/w3m/archive/v0.5.3+git20190105.tar.gz",
+    "maintainer": "@termux"
+  },
+  {
+    "name": "wasmedge",
+    "version": "0.9.1",
+    "description": "A lightweight, high-performance, and extensible WebAssembly runtime",
+    "homepage": "https://wasmedge.org/",
+    "depends": ["libc++", "libllvm"],
+    "srcurl": "https://github.com/WasmEdge/WasmEdge/archive/refs/tags/0.9.1.tar.gz",
     "maintainer": "@termux"
   },
   {

--- a/packages.json
+++ b/packages.json
@@ -4826,11 +4826,11 @@
   },
   {
     "name": "libflac",
-    "version": "1.3.3",
+    "version": "1.3.4",
     "description": "FLAC (Free Lossless Audio Codec) library",
     "homepage": "https://xiph.org/flac/",
     "depends": ["libc++", "libogg"],
-    "srcurl": "https://github.com/xiph/flac/archive/1.3.3.tar.gz",
+    "srcurl": "https://github.com/xiph/flac/archive/1.3.4.tar.gz",
     "maintainer": "@termux"
   },
   {
@@ -6788,11 +6788,11 @@
   },
   {
     "name": "libxml2",
-    "version": "2.9.12",
+    "version": "2.9.13",
     "description": "Library for parsing XML documents",
     "homepage": "http://www.xmlsoft.org",
     "depends": ["libiconv", "liblzma", "zlib"],
-    "srcurl": "ftp://xmlsoft.org/libxml2/libxml2-2.9.12.tar.gz",
+    "srcurl": "https://download.gnome.org/sources/libxml2/2.9/libxml2-2.9.13.tar.xz",
     "maintainer": "@termux"
   },
   {
@@ -6815,11 +6815,11 @@
   },
   {
     "name": "libxslt",
-    "version": "1.1.34",
+    "version": "1.1.35",
     "description": "XSLT processing library",
     "homepage": "http://xmlsoft.org/libxslt/",
     "depends": ["libxml2", "libgcrypt", "libgpg-error", "zlib"],
-    "srcurl": "ftp://xmlsoft.org/libxslt/libxslt-1.1.34.tar.gz",
+    "srcurl": "https://download.gnome.org/sources/libxslt/1.1/libxslt-1.1.35.tar.xz",
     "maintainer": "@termux"
   },
   {
@@ -8819,11 +8819,11 @@
   },
   {
     "name": "php",
-    "version": "8.1.0",
+    "version": "8.1.3",
     "description": "Server-side, HTML-embedded scripting language",
     "homepage": "https://php.net",
     "depends": ["freetype", "libandroid-glob", "libandroid-support", "libbz2", "libcrypt", "libcurl", "libgd", "libgmp", "libiconv", "liblzma", "libresolv-wrapper", "libsqlite", "libxml2", "libxslt", "libzip", "oniguruma", "openssl", "pcre2", "readline", "zlib", "libicu", "libffi", "tidy", "zstd"],
-    "srcurl": "https://github.com/php/php-src/archive/php-8.1.0.tar.gz",
+    "srcurl": "https://github.com/php/php-src/archive/php-8.1.3.tar.gz",
     "maintainer": "@termux"
   },
   {
@@ -8873,11 +8873,11 @@
   },
   {
     "name": "php7",
-    "version": "7.4.27",
+    "version": "7.4.28",
     "description": "Server-side, HTML-embedded scripting language",
     "homepage": "https://php.net",
     "depends": ["freetype", "libandroid-glob", "libandroid-support", "libbz2", "libcrypt", "libcurl", "libgd", "libgmp", "libiconv", "liblzma", "libsqlite", "libxml2", "libxslt", "libzip", "oniguruma", "openssl", "pcre2", "readline", "zlib", "libicu", "libffi", "tidy"],
-    "srcurl": "https://github.com/php/php-src/archive/php-7.4.27.tar.gz",
+    "srcurl": "https://github.com/php/php-src/archive/php-7.4.28.tar.gz",
     "maintainer": "@xtkoba"
   },
   {
@@ -10751,7 +10751,7 @@
     "name": "termux-licenses",
     "version": "2.0",
     "description": "Contains LICENSE files for common licenses",
-    "homepage": "https://termux.com",
+    "homepage": "https://termux.org",
     "depends": [],
     "maintainer": "@termux"
   },
@@ -10766,9 +10766,9 @@
   },
   {
     "name": "termux-tools",
-    "version": "0.162",
+    "version": "0.163",
     "description": "Basic system tools for Termux",
-    "homepage": "https://termux.com/",
+    "homepage": "https://termux.org/",
     "depends": ["bzip2", "coreutils", "curl", "dash", "diffutils", "findutils", "gawk", "grep", "gzip", "less", "procps", "psmisc", "sed", "tar", "termux-am", "termux-am-socket", "termux-exec", "util-linux", "xz-utils", "dialog"],
     "maintainer": "@termux"
   },

--- a/packages.json
+++ b/packages.json
@@ -1086,11 +1086,11 @@
   },
   {
     "name": "cicada",
-    "version": "0.9.24",
+    "version": "0.9.25",
     "description": "A bash like Unix shell",
     "homepage": "https://github.com/mitnk/cicada",
     "depends": [],
-    "srcurl": "https://github.com/mitnk/cicada/archive/v0.9.24.tar.gz",
+    "srcurl": "https://github.com/mitnk/cicada/archive/v0.9.25.tar.gz",
     "maintainer": "Hugo Wang <w@mitnk.com>"
   },
   {
@@ -9780,11 +9780,11 @@
   },
   {
     "name": "samba",
-    "version": "4.14.10",
+    "version": "4.14.12",
     "description": "SMB/CIFS fileserver",
     "homepage": "https://www.samba.org/",
     "depends": ["libbsd", "libcap", "libcrypt", "libgnutls", "libiconv", "libicu", "libpopt", "libtalloc", "libtirpc", "ncurses", "openssl", "readline", "zlib"],
-    "srcurl": "https://download.samba.org/pub/samba/samba-4.14.10.tar.gz",
+    "srcurl": "https://download.samba.org/pub/samba/samba-4.14.12.tar.gz",
     "maintainer": "@termux"
   },
   {
@@ -10171,7 +10171,7 @@
     "description": "Relay for bidirectional data transfer between two independent data channels",
     "homepage": "http://www.dest-unreach.org/socat/",
     "depends": ["openssl", "readline"],
-    "srcurl": "http://www.dest-unreach.org/socat/download/socat-1.7.4.1.tar.gz",
+    "srcurl": "http://www.dest-unreach.org/socat/download/Archive/socat-1.7.4.1.tar.gz",
     "maintainer": "@termux"
   },
   {
@@ -10643,7 +10643,7 @@
   },
   {
     "name": "teleport-tsh",
-    "version": "5.1.2",
+    "version": "8.3.1",
     "description": "Secure Access for Developers that doesn't get in the way",
     "homepage": "https://github.com/gravitational/teleport",
     "depends": [],

--- a/packages.json
+++ b/packages.json
@@ -789,15 +789,6 @@
     "maintainer": "@termux"
   },
   {
-    "name": "btfs",
-    "version": "1.6.0",
-    "description": "Decentralized file system integrating with TRON network",
-    "homepage": "https://www.bittorrent.com/btfs/",
-    "depends": [],
-    "srcurl": "https://github.com/TRON-US/go-btfs/archive/refs/tags/btfs-v1.6.0.tar.gz",
-    "maintainer": "@termux"
-  },
-  {
     "name": "btfs2",
     "version": "2.1.0",
     "description": "Decentralized file system integrating with TRON network and Bittorrent network",
@@ -1086,11 +1077,11 @@
   },
   {
     "name": "cicada",
-    "version": "0.9.25",
+    "version": "0.9.26",
     "description": "A bash like Unix shell",
     "homepage": "https://github.com/mitnk/cicada",
     "depends": [],
-    "srcurl": "https://github.com/mitnk/cicada/archive/v0.9.25.tar.gz",
+    "srcurl": "https://github.com/mitnk/cicada/archive/v0.9.26.tar.gz",
     "maintainer": "Hugo Wang <w@mitnk.com>"
   },
   {

--- a/packages.json
+++ b/packages.json
@@ -7832,11 +7832,11 @@
   },
   {
     "name": "nano",
-    "version": "6.0",
+    "version": "6.2",
     "description": "Small, free and friendly text editor",
     "homepage": "https://www.nano-editor.org/",
     "depends": ["libandroid-support", "libandroid-glob", "ncurses"],
-    "srcurl": "https://nano-editor.org/dist/latest/nano-6.0.tar.xz",
+    "srcurl": "https://nano-editor.org/dist/latest/nano-6.2.tar.xz",
     "maintainer": "@termux"
   },
   {

--- a/packages.json
+++ b/packages.json
@@ -377,11 +377,11 @@
   },
   {
     "name": "assimp",
-    "version": "5.2.1",
+    "version": "5.2.2",
     "description": "Library to import various well-known 3D model formats in an uniform manner",
     "homepage": "http://assimp.sourceforge.net/index.html",
     "depends": ["boost", "zlib"],
-    "srcurl": "https://github.com/assimp/assimp/archive/v5.2.1.tar.gz",
+    "srcurl": "https://github.com/assimp/assimp/archive/v5.2.2.tar.gz",
     "maintainer": "@termux"
   },
   {
@@ -2836,6 +2836,15 @@
     "maintainer": "@termux"
   },
   {
+    "name": "gitui",
+    "version": "0.20.1",
+    "description": "Blazing fast terminal-ui for git written in rust",
+    "homepage": "https://github.com/extrawurst/gitui",
+    "depends": ["git", "zlib", "openssl"],
+    "srcurl": "https://github.com/extrawurst/gitui/archive/v0.20.1.tar.gz",
+    "maintainer": "@PeroSar"
+  },
+  {
     "name": "gkermit",
     "version": "1.00",
     "description": "Simple, Portable, Free File Transfer Software for UNIX",
@@ -3599,11 +3608,11 @@
   },
   {
     "name": "i2pd",
-    "version": "2.40.0",
+    "version": "2.41.0",
     "description": "A full-featured C++ implementation of the I2P router",
     "homepage": "https://i2pd.website/",
     "depends": ["boost", "miniupnpc", "openssl", "zlib"],
-    "srcurl": "https://github.com/PurpleI2P/i2pd/archive/2.40.0.tar.gz",
+    "srcurl": "https://github.com/PurpleI2P/i2pd/archive/2.41.0.tar.gz",
     "maintainer": "@termux"
   },
   {
@@ -4790,11 +4799,11 @@
   },
   {
     "name": "libexpat",
-    "version": "2.4.5",
+    "version": "2.4.6",
     "description": "XML parsing C library",
     "homepage": "https://libexpat.github.io/",
     "depends": [],
-    "srcurl": "https://github.com/libexpat/libexpat/releases/download/R_2_4_5/expat-2.4.5.tar.bz2",
+    "srcurl": "https://github.com/libexpat/libexpat/releases/download/R_2_4_6/expat-2.4.6.tar.bz2",
     "maintainer": "@termux"
   },
   {
@@ -9188,11 +9197,11 @@
   },
   {
     "name": "proxmark3-git",
-    "version": "2022.02.10-c41eab99",
+    "version": "2022.02.19-7310834b",
     "description": "The Swiss Army Knife of RFID Research - RRG/Iceman repo",
     "homepage": "https://github.com/RfidResearchGroup/proxmark3",
     "depends": ["libbz2", "libc++", "readline"],
-    "srcurl": "https://github.com/RfidResearchGroup/proxmark3/archive/c41eab99c0ae3636bf095a741d95d1b0395c6db7.tar.gz",
+    "srcurl": "https://github.com/RfidResearchGroup/proxmark3/archive/7310834b69197efdaa9302aa83a510fafb295e04.tar.gz",
     "maintainer": "Marlin Sööse <marlin.soose@laro.se>"
   },
   {
@@ -9494,11 +9503,11 @@
   },
   {
     "name": "recode",
-    "version": "3.7.9",
+    "version": "3.7.12",
     "description": "Charset converter tool and library",
     "homepage": "https://github.com/pinard/Recode",
     "depends": ["libiconv"],
-    "srcurl": "https://github.com/rrthomas/recode/releases/download/v3.7.9/recode-3.7.9.tar.gz",
+    "srcurl": "https://github.com/rrthomas/recode/releases/download/v3.7.12/recode-3.7.12.tar.gz",
     "maintainer": "Marlin Sööse <marlin.soose@laro.se>"
   },
   {
@@ -13956,11 +13965,11 @@
   },
   {
     "name": "picom",
-    "version": "8.2",
+    "version": "9.1",
     "description": "A lightweight compositor for X11",
     "homepage": "https://github.com/yshui/picom",
     "depends": ["libx11", "libxcb", "xcb-util", "xcb-util-image", "xcb-util-renderutil", "libxext", "xorgproto", "libpixman", "dbus", "libconfig", "mesa", "pcre", "libev", "uthash"],
-    "srcurl": "https://github.com/yshui/picom/archive/refs/tags/v8.2.tar.gz",
+    "srcurl": "https://github.com/yshui/picom/archive/refs/tags/v9.1.tar.gz",
     "maintainer": "Rafael Kitover <rkitover@gmail.com>"
   },
   {

--- a/packages.json
+++ b/packages.json
@@ -628,11 +628,11 @@
   },
   {
     "name": "binutils",
-    "version": "2.37",
+    "version": "2.38",
     "description": "Collection of binary tools, the main ones being ld, the GNU linker, and as, the GNU assembler",
     "homepage": "https://www.gnu.org/software/binutils/",
     "depends": ["libc++", "zlib"],
-    "srcurl": "https://mirrors.kernel.org/gnu/binutils/binutils-2.37.tar.xz",
+    "srcurl": "https://mirrors.kernel.org/gnu/binutils/binutils-2.38.tar.xz",
     "maintainer": "@termux"
   },
   {
@@ -1838,11 +1838,11 @@
   },
   {
     "name": "doxygen",
-    "version": "1.9.2",
+    "version": "1.9.3",
     "description": "A documentation system for C++, C, Java, IDL and PHP",
     "homepage": "http://www.doxygen.org",
     "depends": ["libc++", "libiconv"],
-    "srcurl": "https://github.com/doxygen/doxygen/archive/Release_1_9_2.tar.gz",
+    "srcurl": "https://github.com/doxygen/doxygen/archive/Release_1_9_3.tar.gz",
     "maintainer": "@termux"
   },
   {
@@ -1982,11 +1982,11 @@
   },
   {
     "name": "ed",
-    "version": "1.17",
+    "version": "1.18",
     "description": "Classic UNIX line editor",
     "homepage": "https://www.gnu.org/software/ed/",
     "depends": [],
-    "srcurl": "https://mirrors.kernel.org/gnu/ed/ed-1.17.tar.lz",
+    "srcurl": "https://mirrors.kernel.org/gnu/ed/ed-1.18.tar.lz",
     "maintainer": "Oliver Schmidhauser @Neo-Oli"
   },
   {


### PR DESCRIPTION
And add helper functions for writing json objects, to make it easier to extend and maintain the script.

Fixes https://github.com/termux/repology-metadata/issues/2.

Example packages.json: https://grimler.se/files/packages.json

