### PR TITLE
Include commit hashes in URLs instead of branch name (master)

### DIFF
--- a/.github/workflows/repology_metadata.yml
+++ b/.github/workflows/repology_metadata.yml
@@ -21,9 +21,9 @@ jobs:
     - name: Clone Termux package repositories
       run: |
         mkdir -p /tmp/repos
-        git clone --depth=1 https://github.com/termux/termux-packages /tmp/repos/main
-        git clone --depth=1 https://github.com/termux/termux-root-packages /tmp/repos/root
-        git clone --depth=1 https://github.com/termux/x11-packages /tmp/repos/x11
+        git clone https://github.com/termux/termux-packages /tmp/repos/main
+        git clone https://github.com/termux/termux-root-packages /tmp/repos/root
+        git clone https://github.com/termux/x11-packages /tmp/repos/x11
     - name: Generate packages.json
       run: |
         bash ./generate-repology-metadata.sh /tmp/repos/*/packages/* > ./packages.json

--- a/generate-repology-metadata.sh
+++ b/generate-repology-metadata.sh
@@ -117,12 +117,14 @@ check_package() {
 	fi
 	print_json_element "maintainer" "$TERMUX_PKG_MAINTAINER"
 
-	print_json_element "package_sources_url" "${repo_url}/tree/master/$(dirname $(git ls-files --full-name build.sh))"
-	print_json_element "package_recipe_url" "${repo_url}/blob/master/$(git ls-files --full-name build.sh)"
-	print_json_element "package_recipe_url_raw" "${repo_raw_url}/master/$(git ls-files --full-name build.sh)"
+	local _COMMIT=$(git log -n1 --format=%h .)
+
+	print_json_element "package_sources_url" "${repo_url}/tree/${_COMMIT}/$(dirname $(git ls-files --full-name build.sh))"
+	print_json_element "package_recipe_url" "${repo_url}/blob/${_COMMIT}/$(git ls-files --full-name build.sh)"
+	print_json_element "package_recipe_url_raw" "${repo_raw_url}/${_COMMIT}/$(git ls-files --full-name build.sh)"
 	local patches=$(git ls-files --full-name "*.patch" "*.patch32" "*.patch64" "*.patch.beforehostbuild" "*.diff")
-	print_json_array "package_patch_urls" "$(for p in $patches; do echo $repo_url/blob/master/$p; done)"
-	print_json_array "package_patch_raw_urls" "$(for p in $patches; do echo $repo_raw_url/master/$p; done)" false
+	print_json_array "package_patch_urls" "$(for p in $patches; do echo $repo_url/blob/${_COMMIT}/$p; done)"
+	print_json_array "package_patch_raw_urls" "$(for p in $patches; do echo $repo_raw_url/${_COMMIT}/$p; done)" false
 
 	# last printed entry needs to have "false" as third argument to avoid trailing ","
 


### PR DESCRIPTION
Currently Repology Metadata is generated every 6 hours, so during the
moment a package is updated in repo and new Metadata is generated, there
is maximum delay of 6 hours. During these 6 hours, the updated patch may
fail to apply for other people trying to apply patch from master which
was indeed for other version. Also this will make the metadata quite
history proof.
